### PR TITLE
Fix vehicle creation failures from Vercel frontend

### DIFF
--- a/frontend/src/lib/api/vehicles.ts
+++ b/frontend/src/lib/api/vehicles.ts
@@ -63,7 +63,7 @@ async function getAuthHeaders(): Promise<HeadersInit> {
   };
 }
 
-function getErrorMessage(response: Response): string {
+async function getErrorMessage(response: Response): Promise<string> {
   try {
     const contentType = response.headers.get('content-type');
     if (contentType && contentType.includes('application/json')) {
@@ -100,7 +100,7 @@ export async function getVehicles(): Promise<Vehicle[]> {
     });
 
     if (!response.ok) {
-      throw new Error(getErrorMessage(response));
+      throw new Error(await getErrorMessage(response));
     }
 
     const result = await response.json();
@@ -118,7 +118,7 @@ export async function getVehicle(id: string): Promise<Vehicle> {
     });
 
     if (!response.ok) {
-      throw new Error(getErrorMessage(response));
+      throw new Error(await getErrorMessage(response));
     }
 
     const result = await response.json();
@@ -138,7 +138,7 @@ export async function createVehicle(data: CreateVehicleRequest): Promise<Vehicle
     });
 
     if (!response.ok) {
-      const errorMsg = getErrorMessage(response);
+      const errorMsg = await getErrorMessage(response);
       console.error('Create vehicle failed:', { status: response.status, error: errorMsg });
       throw new Error(errorMsg);
     }
@@ -164,7 +164,7 @@ export async function updateVehicle(id: string, data: UpdateVehicleRequest): Pro
     });
 
     if (!response.ok) {
-      throw new Error(getErrorMessage(response));
+      throw new Error(await getErrorMessage(response));
     }
 
     const result = await response.json();
@@ -183,7 +183,7 @@ export async function deleteVehicle(id: string): Promise<void> {
     });
 
     if (!response.ok) {
-      throw new Error(getErrorMessage(response));
+      throw new Error(await getErrorMessage(response));
     }
   } catch (error) {
     console.error('Failed to delete vehicle:', error);


### PR DESCRIPTION
### Motivation
- Users were getting errors when creating/adding vehicles from the Vercel-deployed frontend due to the API rejecting origins and the frontend failing to parse API error responses correctly.

### Description
- Relax CORS in `backend/Program.cs` to accept comma-separated configured origins from `FRONTEND_URL`/`Frontend:Url` and allow secure Vercel hostnames by using `SetIsOriginAllowed` and permitting `https://*.vercel.app`.
- Make `getErrorMessage` in `frontend/src/lib/api/vehicles.ts` asynchronous (`async`) and `await` it at every call site so API error bodies are parsed correctly before creating thrown `Error` instances.
- Files changed: `backend/Program.cs` and `frontend/src/lib/api/vehicles.ts`.

### Testing
- Ran `npx eslint src/lib/api/vehicles.ts` which passed for the modified file.
- Ran `npx tsc --noEmit` which failed due to pre-existing unrelated TypeScript errors (missing UI modules/types in settings pages) and not caused by these changes.
- Attempted `dotnet build` but the .NET SDK is unavailable in this environment so the backend build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699986b7964c8328b18e127c566d9359)